### PR TITLE
Fix missing crypto import in user service

### DIFF
--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -2,6 +2,7 @@ import { Service, Inject } from 'typedi';
 import { Repository } from 'typeorm';
 import { NotFoundError } from 'routing-controllers';
 import { UserProfile } from '../models/user-profile';
+import { randomUUID } from 'crypto';
 
 @Service()
 export class UserService {
@@ -19,7 +20,7 @@ export class UserService {
   }
 
   async create(profile: UserProfile): Promise<string> {
-    const uuid = crypto.randomUUID();
+    const uuid = randomUUID();
     const newProfile = this.repository.create({
       ...profile,
       uuid,


### PR DESCRIPTION
## Summary
- use Node's `randomUUID` for generating user IDs in the backend

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5eb1c0748322b12a190eaf6288cf